### PR TITLE
fix search finger on higher templates

### DIFF
--- a/Fingerprint.py
+++ b/Fingerprint.py
@@ -317,9 +317,9 @@ def fingerSearch():
     rxPacket = bytearray()
     packet = bytearray([
     FPSconstants.FINGERPRINT_SEARCH, 
-    0x01, 
-    0x00, 
-    0x00
+    0x01,  # buffer id
+    0x00, 0x00,  # start page
+    0x03, 0xe8  # page num (1000)
     ])
 
     writePacket(theAddress, FPSconstants.FINGERPRINT_COMMANDPACKET, (len(packet)+2), packet)


### PR DESCRIPTION
hi. 

we're installed a fingerprint reader on our office door, using your library, thanks for your work. but higher template (after 12) it has no result. 

after debugging the serial traffic i found that you set only start page (2 bytes) in FINGERPRINT_SEARCH. In the documentation ( https://github.com/adafruit/Adafruit-Fingerprint-Sensor-Library/blob/master/documentation/ZFM-20_Fingerprint_Module.pdf ) see that request has a page parameter, what is missing in your request:

2 bytes 4 bytes 1 byte 2 bytes 1 byte 1 byte 2 bytes **2 bytes** 2 bytes
Baotou Module address packet IDPacket lengthScript buffer number Start Page **Pages** Checksum

With this patch, all templates working.